### PR TITLE
fix: Resolve QA verification blockers for Auth & Interceptors

### DIFF
--- a/backend/app/api/v1/endpoints/crm_deals.py
+++ b/backend/app/api/v1/endpoints/crm_deals.py
@@ -29,7 +29,7 @@ def get_crm_deal_repo(db: AsyncSession = Depends(get_db)) -> CrmDealRepository:
 
 @router.get("", response_model=List[CrmDealResponse])
 async def get_deals(
-    context: TenantContext = Depends(RequiresPermission("crm:write")),
+    context: TenantContext = Depends(RequiresPermission("crm:read")),
     repo: CrmDealRepository = Depends(get_crm_deal_repo),
 ):
     return await repo.get_all(context.organization_id)
@@ -38,7 +38,7 @@ async def get_deals(
 @router.get("/{deal_id}", response_model=CrmDealResponse)
 async def get_deal(
     deal_id: uuid.UUID,
-    context: TenantContext = Depends(RequiresPermission("crm:write")),
+    context: TenantContext = Depends(RequiresPermission("crm:read")),
     repo: CrmDealRepository = Depends(get_crm_deal_repo),
 ):
     return await repo.get_by_id(deal_id, context.organization_id)

--- a/backend/tests/test_tenant_onboarding.py
+++ b/backend/tests/test_tenant_onboarding.py
@@ -89,7 +89,7 @@ async def test_tenant_onboarding_success(async_db_session: AsyncSession):
         role_res = await async_db_session.execute(role_stmt)
         user_role = role_res.scalars().first()
         assert user_role is not None
-        assert user_role.role == "ADMIN"
+        assert user_role.role == "TENANT_OWNER"
 
 
 @pytest.mark.asyncio

--- a/frontend/src/app/core/guards/admin.guard.ts
+++ b/frontend/src/app/core/guards/admin.guard.ts
@@ -16,12 +16,18 @@ export const adminGuard: CanActivateFn = (route, state) => {
     try {
       // Decode JWT safely without external libraries for this demo
       const payload = JSON.parse(atob(token.split('.')[1]));
-      if (payload.role === 'TENANT_OWNER' || payload.role === 'TENANT_ADMIN' || payload.role === 'SUPER_ADMIN') {
+      const roles = Array.isArray(payload.roles) ? payload.roles : (payload.role ? [payload.role] : []);
+      if (roles.includes('TENANT_OWNER') || roles.includes('TENANT_ADMIN') || roles.includes('SUPER_ADMIN')) {
         return true;
+      } else {
+        console.warn(`AdminGuard rejected access: User does not have admin privileges. Found roles: ${JSON.stringify(roles)}`);
       }
     } catch (e) {
       console.error('Error decoding token', e);
     }
+  } else {
+    console.warn('AdminGuard rejected access: No token found.');
   }
-  return router.createUrlTree(['/crm']);
+  router.navigate(['/crm']);
+  return false;
 };

--- a/frontend/src/app/core/guards/super-admin.guard.ts
+++ b/frontend/src/app/core/guards/super-admin.guard.ts
@@ -16,12 +16,18 @@ export const superAdminGuard: CanActivateFn = (route, state) => {
     try {
       // Decode JWT safely
       const payload = JSON.parse(atob(token.split('.')[1]));
-      if (payload.role === 'SUPER_ADMIN') {
+      const roles = Array.isArray(payload.roles) ? payload.roles : (payload.role ? [payload.role] : []);
+      if (roles.includes('SUPER_ADMIN')) {
         return true;
+      } else {
+        console.warn(`SuperAdminGuard rejected access: User does not have SUPER_ADMIN privileges. Found roles: ${JSON.stringify(roles)}`);
       }
     } catch (e) {
       console.error('Error decoding token', e);
     }
+  } else {
+    console.warn('SuperAdminGuard rejected access: No token found.');
   }
-  return router.createUrlTree(['/crm']); // or login
+  router.navigate(['/crm']);
+  return false;
 };

--- a/frontend/src/app/features/admin/tenant-onboard.component.ts
+++ b/frontend/src/app/features/admin/tenant-onboard.component.ts
@@ -48,7 +48,11 @@ export class TenantOnboardComponent {
         this.isSubmitting.set(false);
       },
       error: (err) => {
-        this.errorMessage.set(err.error?.detail || 'Failed to create workspace');
+        if (err.status === 409) {
+          this.errorMessage.set('Workspace or Email already exists');
+        } else {
+          this.errorMessage.set(err.error?.detail || 'Failed to create workspace');
+        }
         this.isSubmitting.set(false);
       }
     });

--- a/frontend/src/app/features/tenant-onboarding/tenant-onboarding.component.ts
+++ b/frontend/src/app/features/tenant-onboarding/tenant-onboarding.component.ts
@@ -142,7 +142,9 @@ export class TenantOnboardingComponent implements OnInit {
       },
       error: (err) => {
         this.isSubmitting = false;
-        if (err.error && err.error.detail) {
+        if (err.status === 409) {
+          this.errorMessage = 'Workspace or Email already exists';
+        } else if (err.error && err.error.detail) {
           this.errorMessage = typeof err.error.detail === 'string' ? err.error.detail : err.error.detail.detail || 'Onboarding failed';
         } else {
           this.errorMessage = 'An unexpected error occurred during onboarding.';


### PR DESCRIPTION
### Description
This PR addresses several blockers identified during manual QA verification related to Authentication and Interceptors:

1. **Silent Route Guards:** 
   - `admin.guard.ts` and `super-admin.guard.ts` have been updated to properly check against `TENANT_OWNER` and `SUPER_ADMIN` roles by handling both `role` and `roles` array formats present in the JWT payload.
   - When access is denied, these guards will now `console.warn` the reason and actively redirect the user via `router.navigate(['/crm'])` instead of failing silently.
2. **403 Forbidden on `/crm/deals`:**
   - Identified that the `auth.interceptor.ts` is functioning correctly, sending the `X-Organization-Id` header properly. 
   - The issue resided in the backend API endpoints `backend/app/api/v1/endpoints/crm_deals.py` where the GET methods were overly restrictive, asking for `crm:write` permissions instead of `crm:read`. This has been fixed.
3. **Unhandled 409 Conflict on `/onboard`:**
   - Both the public `TenantOnboardingComponent` and the admin-only `TenantOnboardComponent` were failing silently in the UI when attempting to register an existing workspace or email.
   - Added specific checks for `err.status === 409` in the `error` callback blocks, setting a user-friendly error message: *"Workspace or Email already exists"*.
4. **Test Adjustments:**
   - Adjusted `tests/test_tenant_onboarding.py` where the expected initial role for an onboarded admin was incorrectly asserted as `"ADMIN"` instead of `"TENANT_OWNER"`.

### Local Verification & Testing Guide
**Backend Setup & Tests:**
1. Navigate to the backend: `cd backend`
2. Activate your virtual environment: `source venv/bin/activate` (if applicable).
3. Ensure PostgreSQL & Redis are running and `DATABASE_URL` is set.
4. Apply migrations: `alembic upgrade head`
5. Run the backend tests: `pytest tests/test_crm_pipeline.py tests/test_onboarding.py tests/test_tenant_onboarding.py -v`

**Frontend Setup & Verification:**
1. Start the UI: `cd frontend && npx @angular/cli serve`
2. **Test Route Guards:** Open your browser's Developer Tools Console, log in with an account that doesn't have `SUPER_ADMIN` privileges, and try navigating to `/admin/tenant-manager`. You should be redirected back to `/crm` and see a warning printed in the console.
3. **Test `/crm/deals`:** Log in with an account with `crm:read` permissions and verify that the Deals pipeline loads successfully without a 403 Forbidden network error.
4. **Test 409 Conflict Handling:** Log out, navigate to the tenant onboarding flow (`/onboarding`), and submit the form using an email or slug that you know already exists. Verify that the UI displays a red banner stating: "Workspace or Email already exists" rather than silently failing.

---
*PR created automatically by Jules for task [3815662835654249645](https://jules.google.com/task/3815662835654249645) started by @zahiruddinsayed99-sys*