### PR TITLE
fix(crm): Complete Backend Alignment for CRM AI Lead Scoring

### DIFF
--- a/backend/app/schemas/crm_deal.py
+++ b/backend/app/schemas/crm_deal.py
@@ -32,5 +32,8 @@ class CrmDealResponse(CrmDealBase):
     organization_id: uuid.UUID
     created_at: datetime
     updated_at: datetime
+    lead_score: Optional[int] = None
+    intent_signals: Optional[list] = None
+    last_scored_at: Optional[datetime] = None
 
     model_config = ConfigDict(from_attributes=True)


### PR DESCRIPTION
Fixes #93 by updating the `CrmDealResponse` Pydantic schema in the FastAPI backend.

**Context:**
The frontend recently switched from a polling approach to a manual refresh model ("fire-and-forget") for triggering AI Lead Scoring. While the background task generated the scores and updated the PostgreSQL `crm_deals` table correctly, the `CrmDealResponse` schema did not expose these fields, meaning the frontend never received them on page refresh.

**Changes:**
- Added `lead_score: Optional[int] = None`, `intent_signals: Optional[list] = None`, and `last_scored_at: Optional[datetime] = None` to `CrmDealResponse` in `backend/app/schemas/crm_deal.py`.

**Local Verification & Testing Guide:**
1.  **Dependencies & Database:** Ensure a PostgreSQL instance with pgvector and Redis are running locally.
2.  **Environment:** Ensure `DATABASE_URL` is set (e.g., `postgresql+asyncpg://postgres:postgres@localhost:5432/app-db`).
3.  **Migrations:** From the `backend` folder, run `alembic upgrade head`.
4.  **Backend Tests:** Run `cd backend && export PYTHONPATH=. && python -m pytest tests/test_crm_ai_endpoints.py` to ensure all AI lead scoring endpoints pass without errors.
5.  **Manual QA:** Start the backend (`uvicorn app.main:app --reload --port 8000`) and the Angular frontend. Log in, trigger a deal AI score, wait a few seconds, click the refresh button, and verify the UI properly displays the returned AI score payload.

---
*PR created automatically by Jules for task [5700157389279718216](https://jules.google.com/task/5700157389279718216) started by @zahiruddinsayed99-sys*