### PR TITLE
fix(lms): update learner courses endpoint to catalog and fix RBAC

### DIFF
--- a/backend/app/api/v1/lms/learner.py
+++ b/backend/app/api/v1/lms/learner.py
@@ -10,14 +10,14 @@ from app.domain.lms import learner_services
 router = APIRouter()
 
 def require_lms_read(context: TenantContext = Depends(get_tenant_context)):
-    if not context.role:
+    if not context.role or context.role not in ["OWNER", "TENANT_OWNER", "ADMIN", "TENANT_ADMIN", "LMS_MANAGER", "MEMBER", "DOMAIN_MEMBER", "VIEWER"]:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail={"code": "ERR_RBAC_001", "detail": "Insufficient permissions"}
         )
     return context
 
-@router.get("/courses")
+@router.get("/catalog")
 async def get_published_courses(
     db: AsyncSession = Depends(get_db),
     context: TenantContext = Depends(require_lms_read)

--- a/backend/tests/test_lms_learner.py
+++ b/backend/tests/test_lms_learner.py
@@ -164,3 +164,18 @@ async def test_lesson_progress_completion(async_client: AsyncClient, async_db_se
 
     assert enrollment.status == "COMPLETED"
     assert enrollment.completed_at is not None
+
+@pytest.mark.asyncio
+async def test_get_courses_rbac(async_client: AsyncClient, async_db_session, redis_client):
+    org_id = uuid.uuid4()
+    org = Organization(id=org_id, name="Test Org 4", slug=f"test-org-4-{org_id}")
+    async_db_session.add(org)
+    await async_db_session.flush()
+
+    user, token = await create_user_and_token(async_db_session, redis_client, f"learner_courses_{org_id}@lms.com", org, "DOMAIN_MEMBER")
+
+    response = await async_client.get(
+        "/api/v1/lms/catalog",
+        headers={"Authorization": f"Bearer {token}", "X-Organization-Id": str(org_id)},
+    )
+    assert response.status_code == 200

--- a/frontend/src/app/lms-learner/lms-learner.component.ts
+++ b/frontend/src/app/lms-learner/lms-learner.component.ts
@@ -16,7 +16,7 @@ import { environment } from '../../environments/environment';
 export class LmsLearnerComponent implements OnInit {
 
   ngOnInit() {
-    this.http.get<any[]>(`${environment.apiUrl}/lms/courses`).subscribe({
+    this.http.get<any[]>(`${environment.apiUrl}/lms/catalog`).subscribe({
       next: (res) => this.availableCourses.set(res),
       error: (err) => console.error('Failed to load courses:', err)
     });
@@ -39,7 +39,7 @@ export class LmsLearnerComponent implements OnInit {
   quizResult = signal<any>(null);
 
   loadAvailableCourses() {
-    this.http.get<any[]>(`${environment.apiUrl}/lms/courses`).subscribe({
+    this.http.get<any[]>(`${environment.apiUrl}/lms/catalog`).subscribe({
       next: (res) => this.availableCourses.set(res),
       error: (err) => console.error('Failed to load courses:', err)
     });


### PR DESCRIPTION
Changes the LMS learner endpoint for fetching published courses from `GET /api/v1/lms/courses` to `GET /api/v1/lms/catalog` to prevent endpoint collision with the authoring module. Updates `require_lms_read` to properly check that `context.role` is in the allowed roles list, explicitly granting `DOMAIN_MEMBER` access. Updates Angular frontend `LmsLearnerComponent` to fetch from the new `/lms/catalog` endpoint.