### PR TITLE
fix: resolve silent failure in LMS AI quiz generation background task

### DIFF
--- a/backend/app/api/v1/lms/authoring.py
+++ b/backend/app/api/v1/lms/authoring.py
@@ -86,6 +86,6 @@ async def generate_quiz(
 
     # 3. Dispatch Background Worker
     from app.tasks.ai_tasks import generate_ai_quiz
-    background_tasks.add_task(generate_ai_quiz, str(context.organization_id), request.lesson_id)
+    background_tasks.add_task(generate_ai_quiz, None, context.organization_id, request.lesson_id)
 
     return {"status": "accepted"}

--- a/backend/app/tasks/ai_tasks.py
+++ b/backend/app/tasks/ai_tasks.py
@@ -1,5 +1,6 @@
 import uuid
 import asyncio
+import logging
 
 from app.core.redis import get_redis_client, close_redis_client
 from app.core.database import get_engine
@@ -9,6 +10,7 @@ from app.domain.models.organization_document import OrganizationDocument
 from app.domain.models.ai_job import AiJob
 import time
 
+logger = logging.getLogger(__name__)
 
 async def process_document_embeddings(job_id: uuid.UUID, organization_id: uuid.UUID, document_id: uuid.UUID, text_content: str):
     redis = await get_redis_client()
@@ -57,7 +59,7 @@ async def process_document_embeddings(job_id: uuid.UUID, organization_id: uuid.U
     finally:
         await redis.delete(lock_key)
 
-async def generate_ai_quiz(job_id: uuid.UUID, organization_id: uuid.UUID, lesson_id: uuid.UUID):
+async def generate_ai_quiz(job_id: uuid.UUID | None, organization_id: uuid.UUID, lesson_id: uuid.UUID):
     redis = await get_redis_client()
     lock_key = f"ai_lock:quiz_gen:{str(lesson_id)}"
 
@@ -121,6 +123,7 @@ async def generate_ai_quiz(job_id: uuid.UUID, organization_id: uuid.UUID, lesson
                 await db.commit()
 
             except Exception as e:
+                logger.error(f"Error generating AI quiz for lesson {lesson_id}: {e}", exc_info=True)
                 if job_id:
                     from sqlalchemy import update
                     job_stmt = update(AiJob).where(AiJob.id == job_id).values(


### PR DESCRIPTION
Resolves issue #98 where the backend background task for generating AI quizzes was failing silently.

### Root Cause
The `generate_ai_quiz` function signature required 3 arguments (`job_id`, `organization_id`, `lesson_id`), but `authoring.py` was calling it with only 2 arguments. This raised an immediate `TypeError` that was not logged, causing the frontend to poll indefinitely.

### Fix
- Modified `generate_ai_quiz` to accept `job_id: uuid.UUID | None`
- Updated the API router call in `authoring.py` to pass `None` for `job_id`
- Added the standard `logging` module to `ai_tasks.py` to catch and log any exception thrown during quiz generation

### Local Verification & Testing Guide
1. Run backend tests: `cd backend && source .venv/bin/activate && pytest tests/test_lms_ai_quiz.py`
2. Expected outcome: Tests pass successfully and you can trigger the quiz manually via the frontend UI without hanging. Logs in FastAPI terminal will indicate `status: accepted` and no errors will be logged if it is successful, otherwise an exception stack trace will print for debugging.

---
*PR created automatically by Jules for task [13566685257637907637](https://jules.google.com/task/13566685257637907637) started by @zahiruddinsayed99-sys*