### PR TITLE
[Feature] Implement Mock "Upgrade to PRO" Billing Flow

### DIFF
--- a/backend/app/api/v1/endpoints/billing.py
+++ b/backend/app/api/v1/endpoints/billing.py
@@ -181,3 +181,65 @@ async def stripe_webhook(
         await redis.delete(lock_key)
 
     return {"status": "success"}
+
+from app.schemas.billing import UpgradeRequest
+from app.domain.models.user import User
+from app.domain.models.user_role import UserRole
+from app.core.security import create_access_token, create_refresh_token
+from app.core.session import create_session
+
+@router.post("/upgrade")
+async def upgrade_to_pro(
+    payload: UpgradeRequest,
+    context: TenantContext = Depends(RequiresPermission("tenant:billing")),
+    db: AsyncSession = Depends(get_db),
+    redis: aioredis.Redis = Depends(get_redis_client),
+):
+    stmt = select(Organization).where(Organization.id == context.organization_id)
+    result = await db.execute(stmt)
+    organization = result.scalars().first()
+
+    if not organization:
+        raise HTTPException(status_code=404, detail="Organization not found")
+
+    # Update organization tier to PRO
+    organization.subscription_tier = "PRO"
+    organization.subscription_status = "ACTIVE"
+    await db.commit()
+
+    # Re-issue a fresh JWT token to dynamically apply the updated role/tier
+    # We need the user email and roles
+    user_stmt = select(User).where(User.id == context.user_id)
+    user_res = await db.execute(user_stmt)
+    user = user_res.scalars().first()
+
+    roles_stmt = select(UserRole.role).where(UserRole.user_id == context.user_id)
+    roles_res = await db.execute(roles_stmt)
+    active_roles = list(roles_res.scalars().all())
+
+    # We keep the same token_id? Or generate a new one. It's usually better to just use a new one.
+    # But since it's an upgrade without hard logout, let's keep the user's existing token_id if possible, or issue a new one
+    token_id = str(uuid.uuid4())
+
+    access_token, _ = create_access_token(
+        user_id=user.id,
+        email=user.email,
+        roles=active_roles,
+        token_id=token_id,
+    )
+
+    refresh_token, _ = create_refresh_token(
+        user_id=user.id,
+        token_id=token_id,
+    )
+
+    await create_session(
+        redis=redis,
+        user_id=user.id,
+        token_id=token_id,
+        ttl_seconds=7 * 24 * 3600,
+    )
+
+    # Could set the refresh token cookie, but for now just returning the access_token
+    # so frontend can dynamically intercept it
+    return {"access_token": access_token}

--- a/backend/app/schemas/billing.py
+++ b/backend/app/schemas/billing.py
@@ -1,0 +1,7 @@
+from pydantic import BaseModel, constr
+
+class UpgradeRequest(BaseModel):
+    cardNumber: constr(min_length=16, max_length=16, pattern=r'^[0-9]{16}$')
+    expiryDate: constr(min_length=5, max_length=5, pattern=r'^(0[1-9]|1[0-2])\/?([0-9]{2})$')
+    cvv: constr(min_length=3, max_length=4, pattern=r'^[0-9]{3,4}$')
+    nameOnCard: str

--- a/frontend/src/app/features/billing-dashboard/billing-dashboard.component.html
+++ b/frontend/src/app/features/billing-dashboard/billing-dashboard.component.html
@@ -46,7 +46,14 @@
   </div>
 
   <div class="actions mt-4">
-    <button (click)="onCheckout()">Upgrade to PRO (Checkout)</button>
+    <button (click)="onCheckout()">Upgrade to PRO (Stripe Checkout)</button>
+    <button class="btn-upgrade-mock" (click)="openUpgradeModal()">Upgrade to PRO (Mock Checkout)</button>
     <button (click)="onCustomerPortal()">Manage Billing (Portal)</button>
   </div>
+
+  <app-upgrade-modal
+    *ngIf="isUpgradeModalOpen()"
+    (close)="closeUpgradeModal()"
+    (upgradeSuccess)="onUpgradeSuccess()">
+  </app-upgrade-modal>
 </div>

--- a/frontend/src/app/features/billing-dashboard/billing-dashboard.component.scss
+++ b/frontend/src/app/features/billing-dashboard/billing-dashboard.component.scss
@@ -87,3 +87,13 @@
     }
   }
 }
+.btn-upgrade-mock {
+  background-color: #28a745;
+  color: white;
+  margin-left: 10px;
+  margin-right: 10px;
+
+  &:hover {
+    background-color: #218838;
+  }
+}

--- a/frontend/src/app/features/billing-dashboard/billing-dashboard.component.ts
+++ b/frontend/src/app/features/billing-dashboard/billing-dashboard.component.ts
@@ -3,11 +3,12 @@ import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
 import { HttpClient } from '@angular/common/http';
 import { environment } from '../../../environments/environment';
+import { UpgradeModalComponent } from './components/upgrade-modal/upgrade-modal';
 
 @Component({
   selector: 'app-billing-dashboard',
   standalone: true,
-  imports: [CommonModule, FormsModule, ReactiveFormsModule],
+  imports: [CommonModule, FormsModule, ReactiveFormsModule, UpgradeModalComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './billing-dashboard.component.html',
   styleUrls: ['./billing-dashboard.component.scss']
@@ -23,6 +24,7 @@ export class BillingDashboardComponent {
   creditsUsed = signal<number>(50);
   creditsMax = signal<number>(100);
   isSoftLocked = signal<boolean>(false);
+  isUpgradeModalOpen = signal<boolean>(false);
 
   gstinForm = this.fb.group({
     gstin: ['', [Validators.required, Validators.pattern(/^[0-9]{2}[A-Z]{5}[0-9]{4}[A-Z]{1}[1-9A-Z]{1}Z[0-9A-Z]{1}$/)]],
@@ -70,6 +72,7 @@ export class BillingDashboardComponent {
   }
 
   onCheckout() {
+    // Original Stripe Checkout - kept for backward compatibility or real payment
     this.http.post<{ url: string }>(`${environment.apiUrl}/billing/checkout`, {}).subscribe({
       next: (response) => {
         if (response.url) {
@@ -87,5 +90,22 @@ export class BillingDashboardComponent {
         }
       }
     });
+  }
+
+  openUpgradeModal() {
+    this.isUpgradeModalOpen.set(true);
+  }
+
+  closeUpgradeModal() {
+    this.isUpgradeModalOpen.set(false);
+  }
+
+  onUpgradeSuccess() {
+    this.loadBillingInfo();
+    // In a real app we might want to also trigger a global app state update
+    // or re-evaluate gates, but reloading info and having the new JWT in localStorage
+    // usually suffices for the next requests.
+    this.successToast.set(true);
+    setTimeout(() => this.successToast.set(false), 3000);
   }
 }

--- a/frontend/src/app/features/billing-dashboard/components/upgrade-modal/upgrade-modal.html
+++ b/frontend/src/app/features/billing-dashboard/components/upgrade-modal/upgrade-modal.html
@@ -1,0 +1,67 @@
+<div class="modal-backdrop" (click)="onClose()">
+  <div class="modal-content" (click)="$event.stopPropagation()">
+    <div class="modal-header">
+      <h2>Upgrade to PRO</h2>
+      <button class="close-btn" (click)="onClose()">&times;</button>
+    </div>
+
+    <div class="modal-body">
+      <div class="pro-benefits">
+        <h3>PRO Benefits</h3>
+        <ul>
+          <li>Unlimited AI generation</li>
+          <li>Advanced RAG capabilities</li>
+          <li>Priority support</li>
+        </ul>
+      </div>
+
+      <form [formGroup]="paymentForm" (ngSubmit)="onSubmit()">
+        <div class="form-group">
+          <label for="cardNumber">Card Number</label>
+          <input type="text" id="cardNumber" formControlName="cardNumber" placeholder="1234123412341234">
+          <div class="error-msg" *ngIf="paymentForm.get('cardNumber')?.invalid && paymentForm.get('cardNumber')?.touched">
+            Valid 16-digit card number is required.
+          </div>
+        </div>
+
+        <div class="form-row">
+          <div class="form-group">
+            <label for="expiryDate">Expiry Date</label>
+            <input type="text" id="expiryDate" formControlName="expiryDate" placeholder="MM/YY">
+            <div class="error-msg" *ngIf="paymentForm.get('expiryDate')?.invalid && paymentForm.get('expiryDate')?.touched">
+              Valid expiry date (MM/YY) is required.
+            </div>
+          </div>
+
+          <div class="form-group">
+            <label for="cvv">CVV</label>
+            <input type="text" id="cvv" formControlName="cvv" placeholder="123">
+            <div class="error-msg" *ngIf="paymentForm.get('cvv')?.invalid && paymentForm.get('cvv')?.touched">
+              Valid CVV is required.
+            </div>
+          </div>
+        </div>
+
+        <div class="form-group">
+          <label for="nameOnCard">Name on Card</label>
+          <input type="text" id="nameOnCard" formControlName="nameOnCard" placeholder="John Doe">
+          <div class="error-msg" *ngIf="paymentForm.get('nameOnCard')?.invalid && paymentForm.get('nameOnCard')?.touched">
+            Name on card is required.
+          </div>
+        </div>
+
+        <div *ngIf="errorMessage()" class="error-banner">
+          {{ errorMessage() }}
+        </div>
+
+        <div class="modal-footer">
+          <button type="button" class="btn-cancel" (click)="onClose()" [disabled]="isLoading()">Cancel</button>
+          <button type="submit" class="btn-upgrade" [disabled]="isLoading()">
+            <span *ngIf="!isLoading()">Upgrade Now ($99/mo)</span>
+            <span *ngIf="isLoading()">Processing...</span>
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>

--- a/frontend/src/app/features/billing-dashboard/components/upgrade-modal/upgrade-modal.scss
+++ b/frontend/src/app/features/billing-dashboard/components/upgrade-modal/upgrade-modal.scss
@@ -1,0 +1,159 @@
+.modal-backdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal-content {
+  background: white;
+  border-radius: 8px;
+  width: 100%;
+  max-width: 500px;
+  padding: 24px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+
+  h2 {
+    margin: 0;
+    font-size: 1.5rem;
+    color: #333;
+  }
+
+  .close-btn {
+    background: none;
+    border: none;
+    font-size: 1.5rem;
+    cursor: pointer;
+    color: #666;
+
+    &:hover {
+      color: #000;
+    }
+  }
+}
+
+.pro-benefits {
+  background: #f8f9fa;
+  padding: 16px;
+  border-radius: 6px;
+  margin-bottom: 20px;
+
+  h3 {
+    margin-top: 0;
+    margin-bottom: 10px;
+    font-size: 1.1rem;
+    color: #2c3e50;
+  }
+
+  ul {
+    margin: 0;
+    padding-left: 20px;
+    li {
+      margin-bottom: 6px;
+      color: #555;
+    }
+  }
+}
+
+.form-group {
+  margin-bottom: 16px;
+
+  label {
+    display: block;
+    margin-bottom: 6px;
+    font-weight: 500;
+    color: #444;
+  }
+
+  input {
+    width: 100%;
+    padding: 10px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    font-size: 1rem;
+    box-sizing: border-box;
+
+    &:focus {
+      outline: none;
+      border-color: #007bff;
+      box-shadow: 0 0 0 2px rgba(0, 123, 255, 0.25);
+    }
+  }
+
+  .error-msg {
+    color: #dc3545;
+    font-size: 0.85rem;
+    margin-top: 4px;
+  }
+}
+
+.form-row {
+  display: flex;
+  gap: 16px;
+
+  .form-group {
+    flex: 1;
+  }
+}
+
+.error-banner {
+  background: #f8d7da;
+  color: #721c24;
+  padding: 10px;
+  border-radius: 4px;
+  margin-bottom: 16px;
+  border: 1px solid #f5c6cb;
+}
+
+.modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  margin-top: 24px;
+
+  button {
+    padding: 10px 20px;
+    border: none;
+    border-radius: 4px;
+    font-size: 1rem;
+    cursor: pointer;
+    transition: background-color 0.2s;
+
+    &:disabled {
+      opacity: 0.7;
+      cursor: not-allowed;
+    }
+  }
+
+  .btn-cancel {
+    background: #e9ecef;
+    color: #495057;
+
+    &:hover:not(:disabled) {
+      background: #dde2e6;
+    }
+  }
+
+  .btn-upgrade {
+    background: #007bff;
+    color: white;
+    font-weight: 500;
+
+    &:hover:not(:disabled) {
+      background: #0056b3;
+    }
+  }
+}

--- a/frontend/src/app/features/billing-dashboard/components/upgrade-modal/upgrade-modal.ts
+++ b/frontend/src/app/features/billing-dashboard/components/upgrade-modal/upgrade-modal.ts
@@ -1,0 +1,63 @@
+import { Component, EventEmitter, Output, signal, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule, ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
+import { HttpClient } from '@angular/common/http';
+import { environment } from '../../../../../environments/environment';
+
+@Component({
+  selector: 'app-upgrade-modal',
+  standalone: true,
+  imports: [CommonModule, FormsModule, ReactiveFormsModule],
+  templateUrl: './upgrade-modal.html',
+  styleUrls: ['./upgrade-modal.scss']
+})
+export class UpgradeModalComponent {
+  @Output() close = new EventEmitter<void>();
+  @Output() upgradeSuccess = new EventEmitter<void>();
+
+  private http = inject(HttpClient);
+  private fb = inject(FormBuilder);
+
+  isLoading = signal<boolean>(false);
+  errorMessage = signal<string | null>(null);
+
+  paymentForm = this.fb.group({
+    cardNumber: ['', [Validators.required, Validators.pattern(/^[0-9]{16}$/)]],
+    expiryDate: ['', [Validators.required, Validators.pattern(/^(0[1-9]|1[0-2])\/?([0-9]{2})$/)]],
+    cvv: ['', [Validators.required, Validators.pattern(/^[0-9]{3,4}$/)]],
+    nameOnCard: ['', Validators.required]
+  });
+
+  onClose() {
+    this.close.emit();
+  }
+
+  onSubmit() {
+    if (this.paymentForm.invalid) {
+      this.paymentForm.markAllAsTouched();
+      return;
+    }
+
+    this.isLoading.set(true);
+    this.errorMessage.set(null);
+
+    // Simulate 2-second loading
+    setTimeout(() => {
+      this.http.post<{ access_token: string }>(`${environment.apiUrl}/billing/upgrade`, this.paymentForm.value)
+        .subscribe({
+          next: (res) => {
+            if (res.access_token) {
+              localStorage.setItem('access_token', res.access_token);
+            }
+            this.isLoading.set(false);
+            this.upgradeSuccess.emit();
+            this.close.emit();
+          },
+          error: (err) => {
+            this.isLoading.set(false);
+            this.errorMessage.set(err.error?.detail || 'Upgrade failed. Please try again.');
+          }
+        });
+    }, 2000);
+  }
+}


### PR DESCRIPTION
This PR implements the requested simulated checkout flow for upgrading an organization's subscription to PRO. 

**Local Verification & Testing Guide:**
- Backend: Execute unit and integration tests under `backend/` by navigating there and running `export PYTHONPATH=. && export DATABASE_URL="..." && pytest tests/test_billing_integration.py -v`.
- Frontend: Ensure Angular modules build successfully with `npm run build` under `frontend/`. 
- Manual Walkthrough: Login to the Angular UI as an owner of a FREE tier organization (you can mock one or use the default seeder). Attempt an action that is over usage limits (such as adding too many seats) or visit the Billing dashboard. Click the 'Upgrade to PRO (Mock Checkout)' button, fill out the dummy CC form, and wait for the simulated 2s process to finish. The UI should refresh and immediately display your tier as PRO and clear the soft-lock warnings. No hard logout should be required.

---
*PR created automatically by Jules for task [5600347236651815190](https://jules.google.com/task/5600347236651815190) started by @zahiruddinsayed99-sys*